### PR TITLE
[DH-386] bumping ipywidget to fix JS error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,8 @@ dependencies:
 - nbclassic==1.0.0
 - notebook==7.0.7
 - otter-grader==4.3.4 # Based on request from ericvd and sean.morris
-- ipympl==0.7.0
+- ipympl==0.9.4
+- ipywidgets==8.0.7
 - pandas==2.2.2
 - scipy==1.11.3
 - statsmodels==0.14.1


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DH-386 https://github.com/berkeley-dsep-infra/datahub/issues/6269

Decided to just bump ipywidgets but also had to bump ipympl since it was pinned to 0.7.0 and 0.9.4 gets installed when mamba install is run.