### PR TITLE
Bump JupyterLab to v4.5.0 and Notebook to v7.5.0 in the Data8 image

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,18 +14,20 @@ dependencies:
   - jupyter-server-proxy==4.4.0
   - jupyter_server==2.16.0
   - jupyterhub==5.3.0
-  - jupyterlab==4.4.2
+  - jupyterlab==4.5.0
   - jupyterlab-git==0.51.1
   - jupyterlab_rise==0.43.1
   - jupytext==1.17.1
   - nbgitpuller==1.2.2
-  - notebook==7.4.2
+  - notebook==7.5.0
   - otter-grader==6.1.3
   - pip==25.1.1
   - python==3.11.*
 
   # data8
   - attrs==25.3.0
+  # [DH-603] Install datascience package from conda forge 
+  - datascience==0.18.1
   - folium==0.19.6
   - ipykernel==6.29.5
   - ipympl==0.9.7
@@ -39,7 +41,6 @@ dependencies:
   - statsmodels==0.14.4
   - syncthing==1.29.6
   - traitlets=5.14.3
-
 
   # Items not in conda forge
   - pip:
@@ -55,5 +56,3 @@ dependencies:
   # [DH-418] okpy 1.18.1 is not compatibile with otter-grader 6.0.4 because they require conflicting versions of requests
   #  - okpy==1.18.1
     - git+https://github.com/shaneknapp/python-popularity-contest.git@add-error-handling
-  # DH - 557 
-    - datascience==0.18.0


### PR DESCRIPTION
- Move `datascience` package from pip to conda block