### PR TITLE
Bump jupytutor to v0.2.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -47,7 +47,7 @@ dependencies:
   - pip:
     - jupyter-tree-download==1.0.1
   # https://github.com/berkeley-dsep-infra/datahub/issues/7669
-    - jupytutor==0.1.8
+    - jupytutor==0.2.0
   # Export notebooks as PDFs with Chrome
     - nb2pdf==0.6.2
     - nbpdfexport==0.2.1


### PR DESCRIPTION
Hello! I'm on Data 8 course staff. We've just finished an update to Jupytutor and tested with a manual install into a Datahub instance.

Can we get an updated image in place by Wednesday morning, for our first lab sections?

Thank you!