### PR TITLE
Update jupytutor version to 0.2.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -47,7 +47,7 @@ dependencies:
   - pip:
     - jupyter-tree-download==1.0.1
   # https://github.com/berkeley-dsep-infra/datahub/issues/7669
-    - jupytutor==0.2.0
+    - jupytutor==0.2.1
   # Export notebooks as PDFs with Chrome
     - nb2pdf==0.6.2
     - nbpdfexport==0.2.1


### PR DESCRIPTION
Hello! We have a new version of Jupytutor ready, with some small changes.

## Release notes

- Render Markdown in LLM responses
- Small UI tweaks to the chat (make better use of space, distinguish AI-generated content)
- Introduce a patch for upstream bug in v7.5.0 (https://github.com/jupyter/notebook/pull/7782)
- Run JavaScript activation code only on `data8.` and `prob140.` domains, to reduce risk in deploying to main datahub user image

Thank you!