### PR TITLE
Bump jupytutor to v0.3.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -47,7 +47,7 @@ dependencies:
   - pip:
     - jupyter-tree-download==1.0.1
   # https://github.com/berkeley-dsep-infra/datahub/issues/7669
-    - jupytutor==0.2.1
+    - jupytutor==0.3.0
   # Export notebooks as PDFs with Chrome
     - nb2pdf==0.6.2
     - nbpdfexport==0.2.1


### PR DESCRIPTION
See release notes: https://github.com/team-jupytutor/jupytutor/releases/tag/v0.3.0

This should work correctly now on `data8-staging.datahub.berkeley.edu`. I have already tested a manual install in the main Data8 hub, and it seems to behave! No need for a staging test on my end, but it should work if DataHub staff need to poke around there before deploying to prod.

Thank you!