### PR TITLE
Bump jupytutor to v0.3.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -48,7 +48,7 @@ dependencies:
   - pip:
     - jupyter-tree-download==1.0.1
   # https://github.com/berkeley-dsep-infra/datahub/issues/7669
-    - jupytutor==0.3.0
+    - jupytutor==0.3.1
   # Export notebooks as PDFs with Chrome
     - nb2pdf==0.6.2
     - nbpdfexport==0.2.1


### PR DESCRIPTION
Release notes [here](https://github.com/team-jupytutor/jupytutor/releases/tag/v0.3.1)! Mostly we're just adding a field on the client so we can understand more about each request on our server.

cc @balajialg 