### PR TITLE
Version bump: jupytutor==0.4.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -48,7 +48,7 @@ dependencies:
   - pip:
     - jupyter-tree-download==1.0.1
   # https://github.com/berkeley-dsep-infra/datahub/issues/7669
-    - jupytutor==0.3.1
+    - jupytutor==0.4.0
   # Export notebooks as PDFs with Chrome
     - nb2pdf==0.6.2
     - nbpdfexport==0.2.1


### PR DESCRIPTION
Uses the new server API!

https://github.com/team-jupytutor/jupytutor/releases/tag/v0.4.0

tested so far by installing ==0.4.0 within production DataHub. cc @balajialg 